### PR TITLE
Add embed in _f m and _f y

### DIFF
--- a/commands/api_commands.py
+++ b/commands/api_commands.py
@@ -101,11 +101,21 @@ async def f(discord, message):
         if response.status_code == 200:
             data = json.loads(response.text)
             try:
-                await message.channel.send("Date: " + data["date"])
-                await message.channel.send(data["text"])
+                embed = discord.Embed(
+                    title="Date: " + data["date"],
+                    description= data["text"],
+                    color=discord.Color.blue()
+                    )
+
+                await message.channel.send(embed=embed)
                 await message.add_reaction("\U0001f44d")
             except:
-                await message.channel.send(data["text"])
+                embed = discord.Embed(
+                    description=data["text"],
+                    color=discord.Color.blue()
+                    )
+
+                await message.channel.send(embed=embed)
                 await message.add_reaction("\U0001f44d")
         else:
             await message.add_reaction("\U0001F44E")
@@ -117,7 +127,12 @@ async def f(discord, message):
         response = requests.request("GET", url, headers=headers, params=querystring)
         if response.status_code == 200:
             data = json.loads(response.text)
-            await message.channel.send(data["text"])
+            embed = discord.Embed(
+                description=data["text"],
+                color=discord.Color.blue()
+                )
+
+            await message.channel.send(embed=embed)
             await message.add_reaction("\U0001f44d")
         else:
             await message.add_reaction("\U0001F44E")


### PR DESCRIPTION
Embed in _f y and _f m commands

output of _f y and _f m commands will be in embed  

Fixes #---
fixed visual appearance 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

**Test Configuration**:
* OS: linux
* OS Version: Kernel 5.4.0-73-generic 

# Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots:
![image](https://user-images.githubusercontent.com/74916308/122881039-544f5480-d358-11eb-9118-8a2b669a5ef0.png)
![image](https://user-images.githubusercontent.com/74916308/122881105-64673400-d358-11eb-8b17-66d2c9890cd0.png)
![image](https://user-images.githubusercontent.com/74916308/122881171-78129a80-d358-11eb-97e9-306fe12d8144.png)


